### PR TITLE
Fix Google Search in Russian localisation

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -131,7 +131,7 @@ msgid ""
 msgstr ""
 "[('DuckDuckGo', 'https://duckduckgo.com/?q=%s&t=epiphany&kl=ru-ru', '!"
 "ddg'),\n"
-"\t\t\t\t  ('Google', 'https://www.google./search?q=%s', '!g'),\n"
+"\t\t\t\t  ('Google', 'https://www.google.com/search?q=%s', '!g'),\n"
 "\t\t\t\t  ('Bing', 'https://www.bing.com/search?q=%s', '!b')]"
 
 #: data/org.gnome.epiphany.gschema.xml:37


### PR DESCRIPTION
After entering search query URL loses its domain suffix
![Screenshot](https://pp.userapi.com/c849524/v849524293/836fa/zYjCq5E1cDY.jpg)