### PR TITLE
Place tab close buttons on the left in Pantheon

### DIFF
--- a/src/ephy-tab-label.c
+++ b/src/ephy-tab-label.c
@@ -342,11 +342,19 @@ ephy_tab_label_class_init (EphyTabLabelClass *klass)
   /* Bind class to template */
   gtk_widget_class_set_template_from_resource (widget_class, "/org/gnome/epiphany/gtk/tab-label.ui");
 
-  gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, spinner);
-  gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, icon);
-  gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, label);
-  gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, audio_button);
-  gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, close_button);
+  if (is_desktop_pantheon ()) {
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, close_button);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, label);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, audio_button);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, spinner);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, icon);
+  } else {
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, spinner);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, icon);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, label);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, audio_button);
+    gtk_widget_class_bind_template_child (widget_class, EphyTabLabel, close_button);
+  }
 
   gtk_widget_class_bind_template_callback (widget_class, close_button_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, style_updated_cb);


### PR DESCRIPTION
This matches interface with Pantheon Files and Pantheon Terminal (tab close buttons on the left, spinners on the right).

Derived from https://github.com/elementary/os-patches/commit/786f79a05e4f28e9f7e07913d8ac285a42a22156